### PR TITLE
[CI] Run fmt on all builds, and clippy on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -24,20 +24,17 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Rust
-      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-    
+      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add rustfmt
+
     - name: Run rustfmt
       run: cargo fmt -- --check
-      # Run fmt on stable only for now.
-      if: matrix.toolchain == 'stable'
 
     - name: Run clippy
-      run: cargo clippy -- -Dwarnings
-      # Run clippy on stable only for now. Eventually we will move to nightly.
-      if: matrix.toolchain == 'stable'
-    
+      run: rustup component add clippy && cargo clippy -- -Dwarnings
+      if: matrix.toolchain == 'nightly'
+
     - name: Build
       run: cargo build --verbose
-    
+
     - name: Test
       run: cargo test --verbose


### PR DESCRIPTION
Following this change, CI

* Runs rustfmt on all of stable, beta, nightly.
* Runs clippy on nightly instead of stable.