### PR TITLE
Support tokio and fasync in mock-omaha server, tie together with the hello world example

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -18,6 +18,9 @@ publish = false
 
 exclude = [".*"]
 
+[features]
+default = ["tokio"]
+
 [dependencies]
 anyhow = "1.0.75"
 argh = "0.1"
@@ -32,9 +35,12 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
 sha2 = "0.10.6"
 thiserror = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full"], optional = true }
 tracing = "0.1.37"
 url = "1.7.2"
 
 [dev-dependencies]
 proptest = "1.4.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fasync)'] }

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -162,7 +162,7 @@ impl OmahaServer {
 
     /// Spawn the server on the current executor, returning the address of the server.
     #[cfg(target_os = "fuchsia")]
-    pub fn start(arc_server: Arc<Mutex<OmahaServer>>) -> Result<String, Error> {
+    pub async fn start(arc_server: Arc<Mutex<OmahaServer>>) -> Result<String, Error> {
         let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
 
         let (connections, addr) = {
@@ -545,6 +545,7 @@ mod tests {
                 .build()
                 .unwrap(),
         )))
+        .await
         .context("starting server")?;
 
         let client = fuchsia_hyper::new_client();
@@ -605,6 +606,7 @@ mod tests {
                 .build()
                 .unwrap(),
         )))
+        .await
         .context("starting server")?;
 
         {
@@ -715,6 +717,7 @@ mod tests {
                 .build()
                 .unwrap(),
         )))
+        .await
         .context("starting server")?;
 
         let client = fuchsia_hyper::new_client();
@@ -753,6 +756,7 @@ mod tests {
                 .build()
                 .unwrap(),
         )))
+        .await
         .context("starting server")?;
 
         let client = fuchsia_hyper::new_client();
@@ -801,6 +805,7 @@ mod tests {
                 .build()
                 .unwrap(),
         )))
+        .await
         .context("starting server")
         .unwrap();
 

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -412,6 +412,7 @@ pub async fn handle_request(
     req: Request<Body>,
     omaha_server: &Mutex<OmahaServer>,
 ) -> Result<Response<Body>, Error> {
+    tracing::debug!("{:#?}", req);
     if req.uri().path() == "/set_responses_by_appid" {
         return handle_set_responses(req, omaha_server).await;
     }

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -12,7 +12,11 @@ use crate::hash::Hash;
 
 use anyhow::Error;
 use derive_builder::Builder;
+use futures::prelude::*;
 use hyper::body::Bytes;
+use hyper::server::accept::from_stream;
+use hyper::server::Server;
+use hyper::service::{make_service_fn, service_fn};
 use hyper::{header, Body, Method, Request, Response, StatusCode};
 use omaha_client::cup_ecdsa::test_support::{
     make_default_private_key_for_test, make_default_public_key_id_for_test,
@@ -22,27 +26,37 @@ use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::str::FromStr;
+use std::sync::Arc;
 use url::Url;
 
-#[cfg(not(target_os = "fuchsia"))]
-use tokio::sync::Mutex;
-
-#[cfg(target_os = "fuchsia")]
+#[cfg(feature = "tokio")]
 use {
-    fuchsia_async as fasync,
-    fuchsia_sync::Mutex,
-    futures::prelude::*,
-    hyper::{
-        server::{accept::from_stream, Server},
-        service::{make_service_fn, service_fn},
-    },
-    std::{
-        convert::Infallible,
-        net::{Ipv4Addr, SocketAddr},
-        sync::Arc,
-    },
+    async_net::TcpListener,
+    async_net::TcpStream,
+    std::io,
+    std::pin::Pin,
+    std::task::{Context, Poll},
+    tokio::sync::Mutex,
+    tokio::task::JoinHandle,
 };
+
+#[cfg(fasync)]
+use {fuchsia_async as fasync, fuchsia_async::Task, fuchsia_sync::Mutex};
+
+#[cfg(all(fasync, not(target_os = "fuchsia")))]
+use {
+    async_net::TcpListener,
+    async_net::TcpStream,
+    std::io,
+    std::pin::Pin,
+    std::task::{Context, Poll},
+};
+
+#[cfg(all(fasync, target_os = "fuchsia"))]
+use fuchsia_async::net::TcpListener;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize)]
 pub enum OmahaResponse {
@@ -131,6 +145,54 @@ pub enum UpdateCheckAssertion {
     UpdatesDisabled,
 }
 
+/// Adapt [async_net::TcpStream] to work with hyper.
+#[cfg(any(feature = "tokio", all(fasync, not(target_os = "fuchsia"))))]
+#[derive(Debug)]
+pub enum ConnectionStream {
+    Tcp(TcpStream),
+}
+
+#[cfg(any(feature = "tokio", all(fasync, not(target_os = "fuchsia"))))]
+impl tokio::io::AsyncRead for ConnectionStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match &mut *self {
+            ConnectionStream::Tcp(t) => Pin::new(t).poll_read(cx, buf.initialize_unfilled()),
+        }
+        .map_ok(|sz| {
+            buf.advance(sz);
+        })
+    }
+}
+
+#[cfg(any(feature = "tokio", all(fasync, not(target_os = "fuchsia"))))]
+impl tokio::io::AsyncWrite for ConnectionStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            ConnectionStream::Tcp(t) => Pin::new(t).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            ConnectionStream::Tcp(t) => Pin::new(t).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            ConnectionStream::Tcp(t) => Pin::new(t).poll_close(cx),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Builder)]
 #[builder(pattern = "owned")]
 #[builder(derive(Debug))]
@@ -160,13 +222,33 @@ impl OmahaServer {
         }
     }
 
-    /// Spawn the server on the current executor, returning the address of the server.
-    #[cfg(target_os = "fuchsia")]
-    pub async fn start(arc_server: Arc<Mutex<OmahaServer>>) -> Result<String, Error> {
-        let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
+    /// Start the server detached, returning the address of the server
+    pub async fn start_and_detach(
+        arc_server: Arc<Mutex<OmahaServer>>,
+        addr: Option<SocketAddr>,
+    ) -> Result<String, Error> {
+        let (addr, _server_task) = OmahaServer::start(arc_server, addr).await?;
+        #[cfg(fasync)]
+        _server_task.expect("no server task found").detach();
+
+        Ok(addr)
+    }
+
+    /// Spawn the server on the current executor, returning the address of the server and
+    /// its Task.
+    #[cfg(all(fasync, target_os = "fuchsia"))]
+    pub async fn start(
+        arc_server: Arc<Mutex<OmahaServer>>,
+        addr: Option<SocketAddr>,
+    ) -> Result<(String, Option<Task<()>>), Error> {
+        let addr = if let Some(a) = addr {
+            a
+        } else {
+            SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)
+        };
 
         let (connections, addr) = {
-            let listener = fasync::net::TcpListener::bind(&addr)?;
+            let listener = TcpListener::bind(&addr)?;
             let local_addr = listener.local_addr()?;
             (
                 listener
@@ -191,9 +273,89 @@ impl OmahaServer {
             .serve(make_svc)
             .unwrap_or_else(|e| panic!("error serving omaha server: {e}"));
 
-        fasync::Task::spawn(server).detach();
+        let server_task = fasync::Task::spawn(server);
+        Ok((format!("http://{addr}/"), Some(server_task)))
+    }
 
-        Ok(format!("http://{addr}/"))
+    /// Spawn the server on the current executor, returning the address of the server and
+    /// its Task.
+    #[cfg(all(fasync, not(target_os = "fuchsia")))]
+    pub async fn start(
+        arc_server: Arc<Mutex<OmahaServer>>,
+        addr: Option<SocketAddr>,
+    ) -> Result<(String, Option<Task<()>>), Error> {
+        let addr = if let Some(a) = addr {
+            a
+        } else {
+            SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)
+        };
+
+        let make_svc = make_service_fn(move |_socket| {
+            let arc_server = Arc::clone(&arc_server);
+            async {
+                Ok::<_, Infallible>(service_fn(move |req| {
+                    let arc_server = Arc::clone(&arc_server);
+                    async move { handle_request(req, &arc_server).await }
+                }))
+            }
+        });
+
+        let listener = TcpListener::bind(&addr)
+            .await
+            .expect("cannot bind to address");
+
+        let addr = listener.local_addr()?;
+
+        let server = async move {
+            Server::builder(from_stream(
+                listener.incoming().map_ok(ConnectionStream::Tcp),
+            ))
+            .executor(fuchsia_hyper::Executor)
+            .serve(make_svc)
+            .await
+            .unwrap_or_else(|e| panic!("error serving omaha server: {e}"));
+        };
+
+        let server_task = fasync::Task::spawn(server);
+        Ok((format!("http://{addr}/"), Some(server_task)))
+    }
+
+    /// Spawn the server on the current executor, returning the address of the server and
+    /// its JoinHandle.
+    #[cfg(feature = "tokio")]
+    pub async fn start(
+        arc_server: Arc<Mutex<OmahaServer>>,
+        addr: Option<SocketAddr>,
+    ) -> Result<(String, Option<JoinHandle<()>>), Error> {
+        let addr = if let Some(a) = addr {
+            a
+        } else {
+            SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)
+        };
+
+        let make_svc = make_service_fn(move |_socket| {
+            let arc_server = Arc::clone(&arc_server);
+            async {
+                Ok::<_, Infallible>(service_fn(move |req| {
+                    let arc_server = Arc::clone(&arc_server);
+                    async move { handle_request(req, &arc_server).await }
+                }))
+            }
+        });
+
+        let listener = TcpListener::bind(&addr)
+            .await
+            .expect("cannot bind to address");
+
+        let addr = listener.local_addr()?;
+
+        let server_task = tokio::spawn(async move {
+            let connections = listener.incoming().map_ok(ConnectionStream::Tcp);
+            let _ = Server::builder(from_stream(connections))
+                .serve(make_svc)
+                .await;
+        });
+        Ok((format!("http://{addr}/"), Some(server_task)))
     }
 }
 
@@ -267,7 +429,10 @@ pub async fn handle_set_responses(
     let req_json: HashMap<String, ResponseAndMetadata> =
         serde_json::from_slice(&req_body).expect("parse json");
     {
+        #[cfg(feature = "tokio")]
         let mut omaha_server = omaha_server.lock().await;
+        #[cfg(fasync)]
+        let mut omaha_server = omaha_server.lock();
         omaha_server.responses_by_appid = req_json;
     }
 
@@ -281,7 +446,10 @@ pub async fn handle_omaha_request(
     req: Request<Body>,
     omaha_server: &Mutex<OmahaServer>,
 ) -> Result<Response<Body>, Error> {
+    #[cfg(feature = "tokio")]
     let omaha_server = omaha_server.lock().await;
+    #[cfg(fasync)]
+    let omaha_server = omaha_server.lock().clone();
     assert_eq!(req.method(), Method::POST);
 
     if omaha_server.responses_by_appid.is_empty() {
@@ -521,34 +689,51 @@ pub async fn handle_omaha_request(
     Ok(builder.body(Body::from(response_data)).unwrap())
 }
 
-#[cfg(target_os = "fuchsia")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use anyhow::Context;
-    use fuchsia_async as fasync;
+    #[cfg(feature = "tokio")]
+    use hyper::client::HttpConnector;
+    use hyper::Client;
+    #[cfg(fasync)]
+    use {fuchsia_async as fasync, fuchsia_hyper};
 
-    #[fasync::run_singlethreaded(test)]
+    #[cfg(fasync)]
+    async fn new_http_client() -> Client<fuchsia_hyper::HyperConnector> {
+        fuchsia_hyper::new_client()
+    }
+
+    #[cfg(feature = "tokio")]
+    async fn new_http_client() -> Client<HttpConnector> {
+        Client::new()
+    }
+
+    #[cfg_attr(fasync, fasync::run_singlethreaded(test))]
+    #[cfg_attr(feature = "tokio", tokio::test)]
     async fn test_no_validate_version() -> Result<(), Error> {
         // Send a request with no specified version and assert that we don't check.
         // See 0.0.0.1 vs 9.9.9.9 below.
-        let server = OmahaServer::start(Arc::new(Mutex::new(
-            OmahaServerBuilder::default()
-                .responses_by_appid([(
-                    "integration-test-appid-1".to_string(),
-                    ResponseAndMetadata {
-                        response: OmahaResponse::NoUpdate,
-                        version: None,
-                        ..Default::default()
-                    },
-                )])
-                .build()
-                .unwrap(),
-        )))
+        let server = OmahaServer::start_and_detach(
+            Arc::new(Mutex::new(
+                OmahaServerBuilder::default()
+                    .responses_by_appid([(
+                        "integration-test-appid-1".to_string(),
+                        ResponseAndMetadata {
+                            response: OmahaResponse::NoUpdate,
+                            version: None,
+                            ..Default::default()
+                        },
+                    )])
+                    .build()
+                    .unwrap(),
+            )),
+            None,
+        )
         .await
         .context("starting server")?;
 
-        let client = fuchsia_hyper::new_client();
+        let client = new_http_client().await;
         let body = json!({
             "request": {
                 "app": [
@@ -581,36 +766,40 @@ mod tests {
         Ok(())
     }
 
-    #[fasync::run_singlethreaded(test)]
+    #[cfg_attr(fasync, fasync::run_singlethreaded(test))]
+    #[cfg_attr(feature = "tokio", tokio::test)]
     async fn test_server_replies() -> Result<(), Error> {
-        let server_url = OmahaServer::start(Arc::new(Mutex::new(
-            OmahaServerBuilder::default()
-                .responses_by_appid([
-                    (
-                        "integration-test-appid-1".to_string(),
-                        ResponseAndMetadata {
-                            response: OmahaResponse::NoUpdate,
-                            version: Some("0.0.0.1".to_string()),
-                            ..Default::default()
-                        },
-                    ),
-                    (
-                        "integration-test-appid-2".to_string(),
-                        ResponseAndMetadata {
-                            response: OmahaResponse::NoUpdate,
-                            version: Some("0.0.0.2".to_string()),
-                            ..Default::default()
-                        },
-                    ),
-                ])
-                .build()
-                .unwrap(),
-        )))
+        let server_url = OmahaServer::start_and_detach(
+            Arc::new(Mutex::new(
+                OmahaServerBuilder::default()
+                    .responses_by_appid([
+                        (
+                            "integration-test-appid-1".to_string(),
+                            ResponseAndMetadata {
+                                response: OmahaResponse::NoUpdate,
+                                version: Some("0.0.0.1".to_string()),
+                                ..Default::default()
+                            },
+                        ),
+                        (
+                            "integration-test-appid-2".to_string(),
+                            ResponseAndMetadata {
+                                response: OmahaResponse::NoUpdate,
+                                version: Some("0.0.0.2".to_string()),
+                                ..Default::default()
+                            },
+                        ),
+                    ])
+                    .build()
+                    .unwrap(),
+            )),
+            None,
+        )
         .await
         .context("starting server")?;
 
         {
-            let client = fuchsia_hyper::new_client();
+            let client = new_http_client().await;
             let body = json!({
                 "request": {
                     "app": [
@@ -665,7 +854,7 @@ mod tests {
             let request = Request::post(format!("{server_url}set_responses_by_appid"))
                 .body(Body::from(body.to_string()))
                 .unwrap();
-            let client = fuchsia_hyper::new_client();
+            let client = new_http_client().await;
             let response = client.request(request).await?;
             assert_eq!(response.status(), StatusCode::OK);
         }
@@ -686,7 +875,7 @@ mod tests {
                 .body(Body::from(body.to_string()))
                 .unwrap();
 
-            let client = fuchsia_hyper::new_client();
+            let client = new_http_client().await;
             let response = client.request(request).await?;
 
             assert_eq!(response.status(), StatusCode::OK);
@@ -709,18 +898,22 @@ mod tests {
         Ok(())
     }
 
-    #[fasync::run_singlethreaded(test)]
+    #[cfg_attr(fasync, fasync::run_singlethreaded(test))]
+    #[cfg_attr(feature = "tokio", tokio::test)]
     async fn test_no_configured_responses() -> Result<(), Error> {
-        let server = OmahaServer::start(Arc::new(Mutex::new(
-            OmahaServerBuilder::default()
-                .responses_by_appid([])
-                .build()
-                .unwrap(),
-        )))
+        let server = OmahaServer::start_and_detach(
+            Arc::new(Mutex::new(
+                OmahaServerBuilder::default()
+                    .responses_by_appid([])
+                    .build()
+                    .unwrap(),
+            )),
+            None,
+        )
         .await
         .context("starting server")?;
 
-        let client = fuchsia_hyper::new_client();
+        let client = new_http_client().await;
         let body = json!({
             "request": {
                 "app": [
@@ -740,26 +933,30 @@ mod tests {
         Ok(())
     }
 
-    #[fasync::run_singlethreaded(test)]
+    #[cfg_attr(fasync, fasync::run_singlethreaded(test))]
+    #[cfg_attr(feature = "tokio", tokio::test)]
     async fn test_server_expect_cup_nopanic() -> Result<(), Error> {
-        let server_url = OmahaServer::start(Arc::new(Mutex::new(
-            OmahaServerBuilder::default()
-                .responses_by_appid([(
-                    "integration-test-appid-1".to_string(),
-                    ResponseAndMetadata {
-                        response: OmahaResponse::NoUpdate,
-                        version: Some("0.0.0.1".to_string()),
-                        ..Default::default()
-                    },
-                )])
-                .require_cup(true)
-                .build()
-                .unwrap(),
-        )))
+        let server_url = OmahaServer::start_and_detach(
+            Arc::new(Mutex::new(
+                OmahaServerBuilder::default()
+                    .responses_by_appid([(
+                        "integration-test-appid-1".to_string(),
+                        ResponseAndMetadata {
+                            response: OmahaResponse::NoUpdate,
+                            version: Some("0.0.0.1".to_string()),
+                            ..Default::default()
+                        },
+                    )])
+                    .require_cup(true)
+                    .build()
+                    .unwrap(),
+            )),
+            None,
+        )
         .await
         .context("starting server")?;
 
-        let client = fuchsia_hyper::new_client();
+        let client = new_http_client().await;
         let body = json!({
             "request": {
                 "app": [
@@ -786,30 +983,41 @@ mod tests {
         Ok(())
     }
 
-    #[fasync::run_singlethreaded(test)]
-    #[should_panic(expected = "configured to expect CUP")]
-    // TODO(https://fxbug.dev/42169733): delete the below
-    #[cfg_attr(feature = "variant_asan", ignore)]
+    #[cfg_attr(
+        fasync,
+        fasync::run_singlethreaded(test),
+        should_panic(expected = "configured to expect CUP")
+    )]
+    #[cfg_attr(
+        feature = "tokio",
+        tokio::test,
+        should_panic(
+            expected = "called `Result::unwrap()` on an `Err` value: hyper::Error(IncompleteMessage)"
+        )
+    )]
     async fn test_server_expect_cup_panic() {
-        let server_url = OmahaServer::start(Arc::new(Mutex::new(
-            OmahaServerBuilder::default()
-                .responses_by_appid([(
-                    "integration-test-appid-1".to_string(),
-                    ResponseAndMetadata {
-                        response: OmahaResponse::NoUpdate,
-                        version: Some("0.0.0.1".to_string()),
-                        ..Default::default()
-                    },
-                )])
-                .require_cup(true)
-                .build()
-                .unwrap(),
-        )))
+        let server_url = OmahaServer::start_and_detach(
+            Arc::new(Mutex::new(
+                OmahaServerBuilder::default()
+                    .responses_by_appid([(
+                        "integration-test-appid-1".to_string(),
+                        ResponseAndMetadata {
+                            response: OmahaResponse::NoUpdate,
+                            version: Some("0.0.0.1".to_string()),
+                            ..Default::default()
+                        },
+                    )])
+                    .require_cup(true)
+                    .build()
+                    .unwrap(),
+            )),
+            None,
+        )
         .await
         .context("starting server")
         .unwrap();
 
-        let client = fuchsia_hyper::new_client();
+        let client = new_http_client().await;
         let body = json!({
             "request": {
                 "app": [

--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -39,7 +39,7 @@ struct Args {
         option,
         description = "responses and metadata keyed by appid",
         from_str_fn(parse_responses_by_appid),
-        default = "HashMap::new()"
+        default = "parse_responses_by_appid(EXAMPLE_RESPONSES_BY_APPID).unwrap()"
     )]
     responses_by_appid: HashMap<String, ResponseAndMetadata>,
 
@@ -79,6 +79,18 @@ fn parse_responses_by_appid(value: &str) -> Result<HashMap<String, ResponseAndMe
 }
 
 pub const DEFAULT_PRIVATE_KEY_ID: i32 = 42;
+const EXAMPLE_RESPONSES_BY_APPID: &str = r#"
+{
+  "appid_01": {
+    "response": "NoUpdate",
+    "merkle": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "check_assertion": "UpdatesEnabled",
+    "version": "14.20230831.4.72",
+    "codebase": "fuchsia-pkg://omaha.mock.fuchsia.com/",
+    "package_path": "update"
+  }
+}
+"#;
 
 #[cfg_attr(fasync, fasync::run(10))]
 #[cfg_attr(feature = "tokio", tokio::main)]

--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -6,28 +6,19 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use anyhow::Context as _;
 use argh::FromArgs;
-use async_net::{TcpListener, TcpStream};
-use futures::prelude::*;
-use hyper::server::accept::from_stream;
-use hyper::server::Server;
-use hyper::service::{make_service_fn, service_fn};
+use async_net as _;
 use mock_omaha_server::{
-    handle_request, OmahaServerBuilder, PrivateKeyAndId, PrivateKeys, ResponseAndMetadata,
+    OmahaServer, OmahaServerBuilder, PrivateKeyAndId, PrivateKeys, ResponseAndMetadata,
 };
 use std::collections::HashMap;
-use std::convert::Infallible;
-use std::io;
 use std::net::{Ipv6Addr, SocketAddr};
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-#[cfg(not(target_os = "fuchsia"))]
+#[cfg(feature = "tokio")]
 use tokio::sync::Mutex;
 
-#[cfg(target_os = "fuchsia")]
+#[cfg(fasync)]
 use {fuchsia_async as fasync, fuchsia_sync::Mutex};
 
 #[derive(FromArgs)]
@@ -87,105 +78,49 @@ fn parse_responses_by_appid(value: &str) -> Result<HashMap<String, ResponseAndMe
     serde_json::from_str(value).map_err(|e| format!("Parsing failed: {e:?}"))
 }
 
-/// Adapt [async_net::TcpStream] to work with hyper.
-#[derive(Debug)]
-pub enum ConnectionStream {
-    Tcp(TcpStream),
-    #[cfg(target_os = "fuchsia")]
-    Socket(fasync::Socket),
-}
-
-impl tokio::io::AsyncRead for ConnectionStream {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        match &mut *self {
-            ConnectionStream::Tcp(t) => Pin::new(t).poll_read(cx, buf.initialize_unfilled()),
-            #[cfg(target_os = "fuchsia")]
-            ConnectionStream::Socket(t) => {
-                futures::AsyncRead::poll_read(Pin::new(t), cx, buf.initialize_unfilled())
-            }
-        }
-        .map_ok(|sz| {
-            buf.advance(sz);
-        })
-    }
-}
-
-impl tokio::io::AsyncWrite for ConnectionStream {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        match &mut *self {
-            ConnectionStream::Tcp(t) => Pin::new(t).poll_write(cx, buf),
-            #[cfg(target_os = "fuchsia")]
-            ConnectionStream::Socket(t) => futures::AsyncWrite::poll_write(Pin::new(t), cx, buf),
-        }
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            ConnectionStream::Tcp(t) => Pin::new(t).poll_flush(cx),
-            #[cfg(target_os = "fuchsia")]
-            ConnectionStream::Socket(t) => futures::AsyncWrite::poll_flush(Pin::new(t), cx),
-        }
-    }
-
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            ConnectionStream::Tcp(t) => Pin::new(t).poll_close(cx),
-            #[cfg(target_os = "fuchsia")]
-            ConnectionStream::Socket(t) => Pin::new(t).poll_close(cx),
-        }
-    }
-}
-
 pub const DEFAULT_PRIVATE_KEY_ID: i32 = 42;
 
-#[tokio::main]
+#[cfg_attr(fasync, fasync::run(10))]
+#[cfg_attr(feature = "tokio", tokio::main)]
 async fn main() -> Result<(), anyhow::Error> {
     let args: Args = argh::from_env();
 
-    let server = OmahaServerBuilder::default()
-        .responses_by_appid(args.responses_by_appid)
-        .private_keys(PrivateKeys {
-            latest: PrivateKeyAndId {
-                id: args.key_id,
-                key: std::fs::read_to_string(&args.key_path)
-                    .unwrap_or_else(|_| panic!("read from key_path '{:#?}' failed", args.key_path))
-                    .parse()
-                    .expect("failed to parse key"),
-            },
-            historical: vec![],
-        })
-        .require_cup(args.require_cup)
-        .build()
-        .expect("omaha server build");
+    let (local_addr, task) = OmahaServer::start(
+        Arc::new(Mutex::new(
+            OmahaServerBuilder::default()
+                .responses_by_appid(args.responses_by_appid)
+                .private_keys(PrivateKeys {
+                    latest: PrivateKeyAndId {
+                        id: args.key_id,
+                        key: std::fs::read_to_string(&args.key_path)
+                            .unwrap_or_else(|_| {
+                                panic!("read from key_path '{:#?}' failed", args.key_path)
+                            })
+                            .parse()
+                            .expect("failed to parse key"),
+                    },
+                    historical: vec![],
+                })
+                .require_cup(args.require_cup)
+                .build()
+                .expect("omaha server build"),
+        )),
+        Some(SocketAddr::new(args.listen_on.into(), args.port)),
+    )
+    .await?;
 
-    let arc_server = Arc::new(Mutex::new(server));
+    println!("listening on {}", local_addr);
 
-    let addr = SocketAddr::new(args.listen_on.into(), args.port);
-    let listener = TcpListener::bind(&addr).await.context("binding to addr")?;
-    println!("listening on {}", listener.local_addr()?);
-    let connections = listener.incoming().map_ok(ConnectionStream::Tcp);
-
-    let make_svc = make_service_fn(move |_socket| {
-        let arc_server = Arc::clone(&arc_server);
-        async {
-            Ok::<_, Infallible>(service_fn(move |req| {
-                println!("received req: {req:?}");
-                let arc_server = Arc::clone(&arc_server);
-                async move { handle_request(req, &arc_server).await }
-            }))
+    if let Some(t) = task {
+        #[cfg(fasync)]
+        {
+            Ok(t.await)
         }
-    });
-
-    Server::builder(from_stream(connections))
-        .serve(make_svc)
-        .await
-        .context("error serving omaha server")
+        #[cfg(feature = "tokio")]
+        {
+            Ok(t.await?)
+        }
+    } else {
+        Ok(())
+    }
 }

--- a/omaha-client/examples/hello-world/main.rs
+++ b/omaha-client/examples/hello-world/main.rs
@@ -34,7 +34,7 @@ mod timer;
 
 /// Service endpoint of the omaha server to connect to.
 /// This service must be ready to respond for this example program to work.
-const SERVICE_URL: &str = "https://[::1]:35373";
+const SERVICE_URL: &str = "http://[::1]:35373";
 /// App ID of the application for which an update is checked / requested.
 /// The omaha service must know this app ID for this example program to work.
 const APP_ID: &str = "appid_01";

--- a/omaha-client/examples/hello-world/main.rs
+++ b/omaha-client/examples/hello-world/main.rs
@@ -37,7 +37,7 @@ mod timer;
 const SERVICE_URL: &str = "https://[::1]:35373";
 /// App ID of the application for which an update is checked / requested.
 /// The omaha service must know this app ID for this example program to work.
-const APP_ID: &str = "<APP ID TO BE FILLED IN>";
+const APP_ID: &str = "appid_01";
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
This set of changes

* supports both tokio and fasync runtimes
* adds support for GitHub CI for mock-omaha-server
* makes mock-omaha-server and the hello-world example run together out of the box