### PR TITLE
Removes default port from mock-omaha-server, allows to specify service URLs to hello-world

### DIFF
--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -59,7 +59,7 @@ struct Args {
     )]
     key_path: String,
 
-    #[argh(option, description = "which port to serve on", default = "35373")]
+    #[argh(option, description = "which port to serve on", default = "0")]
     port: u16,
 
     #[argh(

--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -25,13 +25,15 @@ use {fuchsia_async as fasync, fuchsia_sync::Mutex};
 /// Arguments for mock-omaha-server.
 struct Args {
     /// A hashmap from appid to response metadata struct.
-    /// Example JSON argument:
+    /// Example JSON argument (the minimal set of required fields per appid):
     ///     {
     ///         "appid_01": {
     ///             "response": "NoUpdate",
     ///             "merkle": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
     ///             "check_assertion": "UpdatesEnabled",
     ///             "version": "0.1.2.3",
+    ///             "codebase": "fuchsia-pkg://omaha.mock.fuchsia.com/",
+    ///             "package_path": "update"
     ///         },
     ///         ...
     ///     }

--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -43,6 +43,7 @@ uuid = { version = "1.1.2", features = ["serde", "v4"] }
 pin-project = "1.0.11"
 
 [dev-dependencies]
+argh = "0.1"
 assert_matches = "1.5.0"
 futures-timer = "0.3.0"
 hyper-rustls = { version = "0.25", features = ["http2"] }

--- a/omaha-client/examples/hello-world/main.rs
+++ b/omaha-client/examples/hello-world/main.rs
@@ -9,6 +9,7 @@
 use {
     anyhow::Error,
     app_set::{AppMetadata, MinimalAppSet},
+    argh::FromArgs,
     futures::{lock::Mutex, stream::FuturesUnordered, FutureExt as _, StreamExt},
     http_request::MinimalHttpRequest,
     metrics::MinimalMetricsReporter,
@@ -32,12 +33,20 @@ mod policy;
 mod storage;
 mod timer;
 
-/// Service endpoint of the omaha server to connect to.
-/// This service must be ready to respond for this example program to work.
-const SERVICE_URL: &str = "http://[::1]:35373";
 /// App ID of the application for which an update is checked / requested.
 /// The omaha service must know this app ID for this example program to work.
 const APP_ID: &str = "appid_01";
+
+#[derive(FromArgs)]
+/// Arguments for the omaha-client hello world example
+struct Args {
+    #[argh(
+        option,
+        short = 'u',
+        description = "URL of the omaha service to connect to, e.g. 'http://[::]:1234'. This service must accept connections."
+    )]
+    url: String,
+}
 
 #[tokio::main]
 async fn main() {
@@ -57,6 +66,8 @@ async fn main() {
 /// It interacts with the actual service used to keep Fuchsia-based smart displays
 /// updated.
 async fn main_inner() -> Result<(), Error> {
+    let args: Args = argh::from_env();
+
     // HTTP
     let http = MinimalHttpRequest::new();
 
@@ -74,7 +85,7 @@ async fn main_inner() -> Result<(), Error> {
             service_pack: "".to_string(),
             arch: "aarch64".to_string(),
         },
-        service_url: SERVICE_URL.to_string(),
+        service_url: args.url,
         omaha_public_keys: None,
     };
 


### PR DESCRIPTION
* mock-omaha-server takes a free port by default, unless a port is specified on the command line
* hello world accepts a command line argument `--service-url <URL>` , so it can be started to match the listening port of the mock server