### PR TITLE
[omaha_client] Bump version to 0.2.0

### DIFF
--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
The omaha client now ships with a 'hello world' example to demonstrate how it is used in practice. This works out of the box with the mock-omaha-server which has landed as a separate package in https://github.com/google/omaha-client/pull/14
This package is slated to be published to crates.io separately.