### PR TITLE
[omaha-client][mock-omaha-server] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omaha Client Library
 
-Updated: 2020-09
+Updated: 2024-08
 
 This is a platform- and product-agnostic implementation of the client end of the
 [Omaha Protocol](https://github.com/google/omaha/blob/HEAD/doc/ServerProtocolV3.md)
@@ -105,3 +105,14 @@ response says there is no update to be performed.
 The error cases on the right involve a need to be reported to Omaha.  They are, in order: a
 malformed response from Omaha, a response and `InstallPlan` that cannot be performed based on the
 current `PolicyData` or a `Policy` decision, or an error during the performing of an update.
+
+# Testing and development
+
+This repository comes with a "hello world" example to demonstrate how the library can be used in
+programs. More details about the example can be found in its own
+[README.md](omaha-client/examples/hello-world/README.md).
+
+This repository also contains a mock server implementation of the omaha protocol which can be used
+for end-to-end testing of programs including the http request/response schemes. The mock server is
+described in its own [README.md](mock-omaha-server/README.md), including a canonical example how
+the hello world example can be run against the mock server.

--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/mock-omaha-server/README.md
+++ b/mock-omaha-server/README.md
@@ -1,0 +1,83 @@
+# Mock-Omaha-Server
+
+Updated: 2024-08
+
+This is an implementation of a subset of the Omaha
+[Omaha server protocol](https://github.com/google/omaha/blob/HEAD/doc/ServerProtocolV3.md)
+which can be used to develop applications based on the
+[omaha-client lib](https://github.com/google/omaha-client).
+
+# Mode of operation
+
+The mock-omaha-server serves as counterpart when testing applications based on the omaha
+client library. It acts as a standalone http server, and responds to client requests depending
+on the app ID in the request. A JSON structure can be supplied on the command line with the
+`--responses_by_appid` argument when starting the mock server. This structure contains the
+map of app ID to responses, for example:
+
+```
+{
+    "appid_01": {
+        "response": "NoUpdate",
+        "merkle": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "check_assertion": "UpdatesEnabled",
+        "version": "0.1.2.3",
+        "codebase": "fuchsia-pkg://omaha.mock.fuchsia.com/",
+        "package_path": "update"
+    },
+    "appid_02": {
+        ...
+    },
+    ...
+}
+```
+
+A default argument `EXAMPLE_RESPONSES_BY_APPID` is supplied in [main.rs](src/main.rs), which
+is used in case no map is supplied on the command line.
+
+# Example session
+
+The code is designed to work out-of-the-box with the "hello-world" example of the omaha-client lib.
+Thus, when working with the source code after a simple git checkout of the
+[omaha-client lib repository](https://github.com/google/omaha-client), the following session
+illustrates how to work with the mock server:
+
+```
+$ git clone https://github.com/google/omaha-client.git
+[... git clone progress ...]
+$ cd omaha-client
+$ cargo run
+   Compiling omaha_client v0.2.0 (/path/to/omaha-client/omaha-client)
+   Compiling mock-omaha-server v0.1.0 (/path/to/omaha-client/mock-omaha-server)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.59s
+     Running `target/debug/mock-omaha-server`
+listening on http://[::]:39205/
+```
+
+Note that, unless the port is specified with the `--port` switch, it will be picked by whatever
+free port the lib gets from the operating system. At this point the mock omaha server is waiting
+for requests, so now the hello-world example can be started **in a second terminal**, specifying
+the URL of the mock server as printed in its output above:
+
+```
+$ cargo run --example hello-world -- -u http://[::]:39205
+[...]
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
+     Running `target/debug/examples/hello-world -u 'http://[::]:39205'`
+Event: ScheduleChange(
+    UpdateCheckSchedule {
+        last_update_time: None,
+        next_update_time: 2024-08-05 09:23:41.527 UTC (1722849821.527518708) and No Monotonic wait: 100ms,
+    },
+)
+[... after a few seconds ...]
+Event: StateChange(
+    CheckingForUpdates(
+        ScheduledTask,
+    ),
+)
+Event: OmahaServerResponse(
+    Response {
+        protocol_version: "3.0",
+
+```

--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
This change adds a README.md for the mock-omaha-server, including to run the hello world example against the mock server. Also, the main README.md is updated accordingly.

Fixed: #21