### PR TITLE
[mock-omaha-server] Allow publishing to crates.io

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -14,7 +14,6 @@ description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/omaha-client"
 readme = "README.md"
-publish = false
 
 exclude = [".*"]
 
@@ -29,7 +28,7 @@ derive_builder = "0.20.0"
 futures = "0.3.19"
 hex = "0.3.2"
 hyper = { version = "0.14.19", features = ["http1", "server", "stream", "tcp"] }
-omaha_client = { path = "../omaha-client" }
+omaha_client = { version = "0.2", path = "../omaha-client" }
 p256 = "0.11.1"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"


### PR DESCRIPTION
This change updates Cargo.toml to allow publishing the mock-omaha-server to crates.io