### PR TITLE
[mock-omaha-server] Fix dependencies for Fuchsia

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -19,27 +19,28 @@ exclude = [".*"]
 
 [features]
 default = ["tokio"]
+tokio = ["dep:tokio", "dep:async-net", "hyper/tcp"]
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = "1.0"
 argh = "0.1"
-async-net = "2.0"
-derive_builder = "0.20.0"
-futures = "0.3.19"
-hex = "0.3.2"
-hyper = { version = "0.14.19", features = ["http1", "server", "stream", "tcp"] }
+async-net = { version = "1.7", optional = true }
+derive_builder = "0.11"
+futures = "0.3"
+hex = "0.3"
+hyper = { version = "0.14.19", features = ["http1", "server", "stream"] }
 omaha_client = { version = "0.2", path = "../omaha-client" }
-p256 = "0.11.1"
-serde = { version = "1.0.147", features = ["derive"] }
+p256 = "0.11"
+serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.87"
-sha2 = "0.10.6"
+sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"], optional = true }
-tracing = "0.1.37"
-url = "1.7.2"
+tracing = "0.1"
+url = "1.7"
 
 [dev-dependencies]
-proptest = "1.4.0"
+proptest = "1.4"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fasync)'] }

--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -7,7 +7,6 @@
 // those terms.
 
 use argh::FromArgs;
-use async_net as _;
 use mock_omaha_server::{
     OmahaServer, OmahaServerBuilder, PrivateKeyAndId, PrivateKeys, ResponseAndMetadata,
 };


### PR DESCRIPTION
Change the dependencies in Cargo.toml such that the resulting crate of the mock-omaha-server does not conflict with the dependency resolution of the Fuchsia third party repository at:
https://cs.opensource.google/fuchsia/fuchsia/+/main:third_party/rust_crates/

Bug: #16