### PR TITLE
[mock-omaha-server] Fix clippy unit arg warning

### DIFF
--- a/mock-omaha-server/src/main.rs
+++ b/mock-omaha-server/src/main.rs
@@ -125,7 +125,8 @@ async fn main() -> Result<(), anyhow::Error> {
     if let Some(t) = task {
         #[cfg(fasync)]
         {
-            Ok(t.await)
+            t.await;
+            Ok(())
         }
         #[cfg(feature = "tokio")]
         {


### PR DESCRIPTION
When using fasync, clippy complains about a unit arg in main.rs. This change allows it to pass successfully. This bug is triggered only when imported into the Fuchsia repository.

Bug: https://fxbug.dev/359180225