### PR TITLE
[mock-omaha-server] Fix server lock when using tokio

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -439,7 +439,7 @@ pub async fn handle_omaha_request(
     omaha_server: &Mutex<OmahaServer>,
 ) -> Result<Response<Body>, Error> {
     #[cfg(feature = "tokio")]
-    let omaha_server = omaha_server.lock().await;
+    let omaha_server = omaha_server.lock().await.clone();
     #[cfg(fasync)]
     let omaha_server = omaha_server.lock().clone();
     assert_eq!(req.method(), Method::POST);


### PR DESCRIPTION
This fixes a missing clone() when obtaining the server lock when handling requests when using the tokio runtime.

Fixed: #27