### PR TITLE
[mock-omaha-server] Fix clippy unnecessary import warning

### DIFF
--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -684,11 +684,11 @@ pub async fn handle_omaha_request(
 mod tests {
     use super::*;
     use anyhow::Context;
+    #[cfg(fasync)]
+    use fuchsia_async as fasync;
     #[cfg(feature = "tokio")]
     use hyper::client::HttpConnector;
     use hyper::Client;
-    #[cfg(fasync)]
-    use {fuchsia_async as fasync, fuchsia_hyper};
 
     #[cfg(fasync)]
     async fn new_http_client() -> Client<fuchsia_hyper::HyperConnector> {


### PR DESCRIPTION
When using fuchsia_hyper, clippy complains about its unnecessary import in the tests section. This change allows it to pass successfully. This warning is triggered only when imported into the Fuchsia repository.

Bug: https://fxbug.dev/359180225