### PR TITLE
Fix clippy warnings with recent rust nightly

### DIFF
--- a/omaha-client/src/cup_ecdsa.rs
+++ b/omaha-client/src/cup_ecdsa.rs
@@ -131,9 +131,10 @@ impl fmt::Display for Nonce {
     }
 }
 
-/// Request decoration return type, containing request internals. Clients of this
-/// library can call .hash() and store/retrieve the hash, or they can inspect the
-/// request, public key ID, nonce used if necessary.
+/// RequestMetadata is a request decoration return type, containing request internals.
+///
+/// Clients of this library can call .hash() and store/retrieve the hash, or they
+/// can inspect the request, public key ID, nonce used if necessary.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RequestMetadata {
     pub request_body: Vec<u8>,

--- a/omaha-client/src/protocol/request.rs
+++ b/omaha-client/src/protocol/request.rs
@@ -87,9 +87,11 @@ pub struct Request {
     pub apps: Vec<App>,
 }
 
-/// This is a serialization wrapper for a Request, as a Request object serializes into a value,
-/// for an object, not an object that is '{"request": {....} }'.  This wrapper provides the request
-/// wrapping that Omaha expects to see.
+/// RequestWrapper is a serialization wrapper for a Request.
+///
+/// A Request object serializes into a value for an object,
+/// not an object that is '{"request": {....} }'.
+/// This wrapper provides the request wrapping that Omaha expects to see.
 #[derive(Debug, Default, Serialize)]
 pub struct RequestWrapper {
     pub request: Request,

--- a/omaha-client/src/request_builder.rs
+++ b/omaha-client/src/request_builder.rs
@@ -331,6 +331,8 @@ impl<'a> RequestBuilder<'a> {
     }
 }
 
+/// Intermediate constructs an http::Request from available data.
+///
 /// As the name implies, this is an intermediate that can be used to construct an http::Request from
 /// the data that's in the Builder.  It allows for type-aware inspection of the constructed protocol
 /// request, as well as the full construction of the http request (uri, headers, body).

--- a/omaha-client/src/state_machine/update_check.rs
+++ b/omaha-client/src/state_machine/update_check.rs
@@ -23,9 +23,10 @@ pub const CONSECUTIVE_FAILED_UPDATE_CHECKS: &str = "consecutive_failed_update_ch
 pub const LAST_UPDATE_TIME: &str = "last_update_time";
 pub const SERVER_DICTATED_POLL_INTERVAL: &str = "server_dictated_poll_interval";
 
-/// The Context provides the protocol context for a given update check operation.  This is
-/// information that's passed to the Policy to allow it to properly reason about what can and cannot
-/// be done at this time.
+/// The Context provides the protocol context for a given update check operation.
+///
+/// The Context provides the information that's passed to the Policy to allow
+/// it to properly reason about what can and cannot be done at this time.
 #[derive(Clone, Debug)]
 pub struct Context {
     /// The last-computed time to next check for an update.
@@ -149,9 +150,10 @@ pub struct AppResponse {
     pub result: Action,
 }
 
-/// The Action is the result of an update check for a single App.  This is just informational, for
-/// the purposes of updating the protocol state.  Any update action should already have been taken
-/// by the Installer.
+/// The Action is the result of an update check for a single App.
+///
+/// This is just informational, for the purposes of updating the protocol state.
+/// Any update action should already have been taken by the Installer.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Action {
     /// Omaha's response was "no update"

--- a/omaha-client/src/storage.rs
+++ b/omaha-client/src/storage.rs
@@ -59,15 +59,15 @@ pub trait Storage {
 
     /// Get a string from the backing store.  Returns None if there is no value for the given key,
     /// or if the value for the key has a different type.
-    fn get_string<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<String>>;
+    fn get_string<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<String>>;
 
     /// Get an int from the backing store.  Returns None if there is no value for the given key,
     /// or if the value for the key has a different type.
-    fn get_int<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<i64>>;
+    fn get_int<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<i64>>;
 
     /// Get a boolean from the backing store.  Returns None if there is no value for the given key,
     /// or if the value for the key has a different type.
-    fn get_bool<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<bool>>;
+    fn get_bool<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<bool>>;
 
     /// Set a value to be stored in the backing store.  The implementation should cache the value
     /// until the |commit()| fn is called, and then persist all cached values at that time.
@@ -75,7 +75,7 @@ pub trait Storage {
         &'a mut self,
         key: &'a str,
         value: &'a str,
-    ) -> BoxFuture<'_, Result<(), Self::Error>>;
+    ) -> BoxFuture<'a, Result<(), Self::Error>>;
 
     /// Set a value to be stored in the backing store.  The implementation should cache the value
     /// until the |commit()| fn is called, and then persist all cached values at that time.
@@ -83,7 +83,7 @@ pub trait Storage {
         &'a mut self,
         key: &'a str,
         value: i64,
-    ) -> BoxFuture<'_, Result<(), Self::Error>>;
+    ) -> BoxFuture<'a, Result<(), Self::Error>>;
 
     /// Set a value to be stored in the backing store.  The implementation should cache the value
     /// until the |commit()| fn is called, and then persist all cached values at that time.
@@ -91,14 +91,14 @@ pub trait Storage {
         &'a mut self,
         key: &'a str,
         value: bool,
-    ) -> BoxFuture<'_, Result<(), Self::Error>>;
+    ) -> BoxFuture<'a, Result<(), Self::Error>>;
 
     /// Remove the value for |key| from the backing store.  The implementation should cache that
     /// the value has been removed until the |commit()| fn is called, and then persist all changes
     /// at that time.
     ///
     /// If there is no value for the key, this should return without error.
-    fn remove<'a>(&'a mut self, key: &'a str) -> BoxFuture<'_, Result<(), Self::Error>>;
+    fn remove<'a>(&'a mut self, key: &'a str) -> BoxFuture<'a, Result<(), Self::Error>>;
 
     /// Persist all cached values to storage.
     fn commit(&mut self) -> BoxFuture<'_, Result<(), Self::Error>>;
@@ -114,7 +114,7 @@ pub trait StorageExt: Storage {
         &'a mut self,
         key: &'a str,
         value: Option<i64>,
-    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+    ) -> BoxFuture<'a, Result<(), Self::Error>> {
         match value {
             Some(value) => self.set_int(key, value),
             None => self.remove(key),
@@ -123,7 +123,7 @@ pub trait StorageExt: Storage {
 
     /// Get a SystemTime from the backing store.  Returns None if there is no value for the given
     /// key, or if the value for the key has a different type.
-    fn get_time<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<SystemTime>> {
+    fn get_time<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<SystemTime>> {
         self.get_int(key)
             .map(|option| option.map(micros_from_epoch_to_system_time))
             .boxed()
@@ -136,12 +136,12 @@ pub trait StorageExt: Storage {
         &'a mut self,
         key: &'a str,
         value: impl Into<SystemTime>,
-    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+    ) -> BoxFuture<'a, Result<(), Self::Error>> {
         self.set_option_int(key, checked_system_time_to_micros_from_epoch(value.into()))
     }
 
     /// Remove the value for |key| from the backing store, log an error message on error.
-    fn remove_or_log<'a>(&'a mut self, key: &'a str) -> BoxFuture<'_, ()> {
+    fn remove_or_log<'a>(&'a mut self, key: &'a str) -> BoxFuture<'a, ()> {
         self.remove(key)
             .unwrap_or_else(move |e| error!("Unable to remove {}: {}", key, e))
             .boxed()

--- a/omaha-client/src/storage/memory.rs
+++ b/omaha-client/src/storage/memory.rs
@@ -69,7 +69,7 @@ impl Storage for MemStorage {
     type Error = StorageErrors;
 
     /// Get a string from the backing store.  Returns None if there is no value for the given key.
-    fn get_string<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<String>> {
+    fn get_string<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<String>> {
         future::ready(match self.data.get(key) {
             Some(Value::String(s)) => Some(s.clone()),
             _ => None,
@@ -78,7 +78,7 @@ impl Storage for MemStorage {
     }
 
     /// Get an int from the backing store.  Returns None if there is no value for the given key.
-    fn get_int<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<i64>> {
+    fn get_int<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<i64>> {
         future::ready(match self.data.get(key) {
             Some(Value::Int(i)) => Some(*i),
             _ => None,
@@ -87,7 +87,7 @@ impl Storage for MemStorage {
     }
 
     /// Get a boolean from the backing store.  Returns None if there is no value for the given key.
-    fn get_bool<'a>(&'a self, key: &'a str) -> BoxFuture<'_, Option<bool>> {
+    fn get_bool<'a>(&'a self, key: &'a str) -> BoxFuture<'a, Option<bool>> {
         future::ready(match self.data.get(key) {
             Some(Value::Bool(b)) => Some(*b),
             _ => None,
@@ -101,7 +101,7 @@ impl Storage for MemStorage {
         &'a mut self,
         key: &'a str,
         value: &'a str,
-    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+    ) -> BoxFuture<'a, Result<(), Self::Error>> {
         self.data
             .insert(key.to_string(), Value::String(value.to_string()));
         self.committed = false;
@@ -114,7 +114,7 @@ impl Storage for MemStorage {
         &'a mut self,
         key: &'a str,
         value: i64,
-    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+    ) -> BoxFuture<'a, Result<(), Self::Error>> {
         self.data.insert(key.to_string(), Value::Int(value));
         self.committed = false;
         future::ready(Ok(())).boxed()
@@ -126,13 +126,13 @@ impl Storage for MemStorage {
         &'a mut self,
         key: &'a str,
         value: bool,
-    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+    ) -> BoxFuture<'a, Result<(), Self::Error>> {
         self.data.insert(key.to_string(), Value::Bool(value));
         self.committed = false;
         future::ready(Ok(())).boxed()
     }
 
-    fn remove<'a>(&'a mut self, key: &'a str) -> BoxFuture<'_, Result<(), Self::Error>> {
+    fn remove<'a>(&'a mut self, key: &'a str) -> BoxFuture<'a, Result<(), Self::Error>> {
         self.data.remove(key);
         self.committed = false;
         future::ready(Ok(())).boxed()

--- a/omaha-client/src/time.rs
+++ b/omaha-client/src/time.rs
@@ -137,6 +137,8 @@ impl ComplexTime {
 //
 // Implementations for `From<>` are found in `mod complex::complex_time_type_conversions`
 
+/// `PartialComplexTime` holds a value for at least one timeline.
+///
 /// `PartialComplexTime` provides a `std::interator::EitherOrBoth`-like type which is specifically
 /// for holding either one, or both, of the time types that make up a `ComplexTime`.  It's a type
 /// that holds a value for at least one of the timelines.


### PR DESCRIPTION
Clippy recently has introduced stricter warnings. The ones for lifetime elision and comment length were relevant for the omaha client lib in several places. This change fixes the reported issues.

Fixed: #30