### PR TITLE
[omaha-client] Bump deps and release version

### DIFF
--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -26,18 +26,18 @@ futures = "0.3"
 hex = "0.4"
 http = "0.2.4"
 hyper = "0.14.19"
-itertools = "0.10"
+itertools = "0.14"
 p256 = "0.11"
-pkcs8 = { version = "0.9.0", features = ["pem"] }
+pkcs8 = { version = "0.9", features = ["pem"] }
 pretty_assertions = "1.2.1"
-rand = "0.8.4"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
+rand = "0.8"
+serde = { version = "1.0.204", features = ["derive"] }
+serde_json = "1.0.128"
 serde_repr = "0.1.7"
 sha2 = "0.10"
 signature = "1.6.4"
-thiserror = "1.0"
-tracing = "0.1.37"
+thiserror = "2.0"
+tracing = "0.1"
 typed-builder = "0.10.0"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 pin-project = "1.0.11"


### PR DESCRIPTION
This bumps some dependencies to newer versions or relax dependencies within semver conventions. Also bumps the version of omaha_client to 0.2.2 in preparation for an update to crates.io.