### PR TITLE
[mock-omaha-client] Move from tracing to log

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -28,6 +28,7 @@ derive_builder = "0.11"
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14.19", features = ["http1", "server", "stream"] }
+log = "0.4"
 omaha_client = { version = "0.2", path = "../omaha-client" }
 p256 = "0.11"
 serde = { version = "1.0.204", features = ["derive"] }
@@ -35,7 +36,6 @@ serde_json = "1.0.87"
 sha2 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"], optional = true }
-tracing = "0.1"
 url = "1.7"
 
 [dev-dependencies]

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -379,7 +379,7 @@ fn make_etag(
     let private_key: &PrivateKey = match private_keys.find(public_key_id) {
         Some(pk) => Some(pk),
         None => {
-            tracing::error!(
+            log::error!(
                 "Could not find public_key_id {:?} in the private_keys map, which only knows about the latest key_id {:?} and the historical key_ids {:?}",
                 public_key_id,
                 private_keys.latest.id,
@@ -409,7 +409,7 @@ pub async fn handle_request(
     req: Request<Body>,
     omaha_server: &Mutex<OmahaServer>,
 ) -> Result<Response<Body>, Error> {
-    tracing::debug!("{:#?}", req);
+    log::debug!("{req:#?}");
     if req.uri().path() == "/set_responses_by_appid" {
         return handle_set_responses(req, omaha_server).await;
     }
@@ -454,7 +454,7 @@ pub async fn handle_omaha_request(
         let builder = Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(header::CONTENT_LENGTH, 0);
-        tracing::error!("Received a request before |responses_by_appid| was set; returning an empty response with status 500.");
+        log::error!("Received a request before |responses_by_appid| was set; returning an empty response with status 500.");
         return Ok(builder.body(Body::empty()).unwrap());
     }
 


### PR DESCRIPTION
Retire the tracing crate, use log instead. Also bump the version number of mock-omaha-client to 0.3.5

Fixed: #41