### PR TITLE
Delete FailedBootAttempts metric

### DIFF
--- a/omaha-client/src/metrics.rs
+++ b/omaha-client/src/metrics.rs
@@ -53,8 +53,6 @@ pub enum Metrics {
     /// running that software, it is sent after the reboot (and includes the
     /// rebooting time).
     WaitedForRebootDuration(Duration),
-    /// Number of times an update failed to boot into new version.
-    FailedBootAttempts(u64),
     /// Record that an Omaha event report was lost.
     OmahaEventLost(Event),
 }


### PR DESCRIPTION
This metric is not monitored or reported by omaha-client