### PR TITLE
[omaha-client] Bump release version

### DIFF
--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
Bumps the version of omaha_client to 0.2.3 in preparation for an update to crates.io.