### PR TITLE
[mock-omaha-server] Update dependencies

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -27,19 +27,19 @@ argh = "0.1"
 derive_builder = "0.11"
 futures = "0.3"
 hex = "0.4"
-hyper = { version = "0.14.19", features = ["http1", "server", "stream"] }
+hyper = { version = "0.14.19", default-features = false, features = ["http1", "server", "stream"] }
 log = "0.4"
 omaha_client = { version = "0.2", path = "../omaha-client" }
 p256 = "0.11"
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 sha2 = "0.10"
-thiserror = "1.0"
+thiserror = "2"
 tokio = { version = "1", features = ["full"], optional = true }
-url = "1.7"
+url = "2"
 
 [dev-dependencies]
-proptest = "1.4"
+proptest = "1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fasync)'] }


### PR DESCRIPTION
This updates some of the dependencies and relaxes some of them, and bump the version number to 0.3.6