### PR TITLE
[omaha-client][mock-omaha-server] Migrate to log, update deps

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -24,12 +24,12 @@ tokio = ["dep:tokio", "hyper/tcp"]
 [dependencies]
 anyhow = "1.0"
 argh = "0.1"
-derive_builder = "0.11"
+derive_builder = "0.20"
 futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14.19", default-features = false, features = ["http1", "server", "stream"] }
 log = "0.4"
-omaha_client = { version = "0.2", path = "../omaha-client" }
+omaha_client = { version = "0.3", path = "../omaha-client" }
 p256 = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.2.3"
+version = "0.3.7"
 edition = "2021"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -27,20 +27,20 @@ hex = "0.4"
 http = "0.2.4"
 hyper = "0.14.19"
 itertools = "0.14"
+log = "0.4"
 p256 = "0.11"
 pkcs8 = { version = "0.9", features = ["pem"] }
 pretty_assertions = "1.2.1"
 rand = "0.8"
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.128"
-serde_repr = "0.1.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_repr = "0.1"
 sha2 = "0.10"
 signature = "1.6.4"
 thiserror = "2.0"
-tracing = "0.1"
-typed-builder = "0.10.0"
+typed-builder = "0.21"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
-pin-project = "1.0.11"
+pin-project = "1.1"
 
 [dev-dependencies]
 argh = "0.1"
@@ -48,4 +48,4 @@ assert_matches = "1.5.0"
 futures-timer = "0.3"
 hyper-rustls = { version = "0.25", features = ["http2"] }
 tokio = { version = "1", features = ["full"] }
-url = "1.7"
+url = "2"

--- a/omaha-client/examples/hello-world/main.rs
+++ b/omaha-client/examples/hello-world/main.rs
@@ -12,6 +12,7 @@ use {
     argh::FromArgs,
     futures::{lock::Mutex, stream::FuturesUnordered, FutureExt as _, StreamExt},
     http_request::MinimalHttpRequest,
+    log::{error, info},
     metrics::MinimalMetricsReporter,
     omaha_client::{
         common::App,
@@ -22,7 +23,6 @@ use {
         time::StandardTimeSource,
     },
     std::rc::Rc,
-    tracing,
 };
 
 mod app_set;
@@ -50,14 +50,14 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
-    tracing::info!("Starting omaha client...");
+    info!("Starting omaha client...");
 
     if let Err(e) = main_inner().await {
-        tracing::error!("Error running omaha-client: {:#}", e);
+        error!("Error running omaha-client: {:#}", e);
         std::process::exit(1);
     }
 
-    tracing::info!("Shutting down omaha client...");
+    info!("Shutting down omaha client...");
 }
 
 /// This demo code sets up a minimal set of structures to get the omaha-client lib's
@@ -149,7 +149,7 @@ async fn main_inner() -> Result<(), Error> {
     let installer = installer::MinimalInstaller { should_fail: false };
 
     // Metrics
-    // Using the minimal reporter for this example. It only logs metrics via tracing::info.
+    // Using the minimal reporter for this example. It only logs metrics via log::info.
     let metrics_reporter = MinimalMetricsReporter;
 
     // Storage

--- a/omaha-client/examples/hello-world/metrics.rs
+++ b/omaha-client/examples/hello-world/metrics.rs
@@ -7,8 +7,8 @@
 // those terms.
 
 use anyhow::Error;
+use log::info;
 use omaha_client::metrics::{Metrics, MetricsReporter};
-use tracing::info;
 
 /// A minimal implementation of MetricsReporter which only log metrics.
 /// Similar to the Stub in the omaha-client lib, but derives clone.

--- a/omaha-client/src/common.rs
+++ b/omaha-client/src/common.rs
@@ -15,11 +15,11 @@ use crate::{
     time::PartialComplexTime,
     version::Version,
 };
+use log::error;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
-use tracing::error;
 use typed_builder::TypedBuilder;
 
 /// Omaha has historically supported multiple methods of counting devices.  Currently, the

--- a/omaha-client/src/metrics/stub.rs
+++ b/omaha-client/src/metrics/stub.rs
@@ -8,7 +8,7 @@
 
 use crate::metrics::{Metrics, MetricsReporter};
 use anyhow::Error;
-use tracing::info;
+use log::info;
 
 /// A stub implementation of MetricsReporter which only log metrics.
 #[derive(Debug)]

--- a/omaha-client/src/request_builder.rs
+++ b/omaha-client/src/request_builder.rs
@@ -22,10 +22,10 @@ use crate::{
     },
 };
 use http;
+use log::{info, warn};
 use std::fmt::Display;
 use std::result;
 use thiserror::Error;
-use tracing::*;
 
 type ProtocolApp = crate::protocol::request::App;
 

--- a/omaha-client/src/state_machine.rs
+++ b/omaha-client/src/state_machine.rs
@@ -35,6 +35,7 @@ use futures::{
     select,
 };
 use http::{response::Parts, Response as HttpResponse};
+use log::{error, info, warn};
 use p256::ecdsa::DerSignature;
 use std::{
     cmp::min,
@@ -45,7 +46,6 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 use thiserror::Error;
-use tracing::{error, info, warn};
 
 pub mod update_check;
 
@@ -1606,7 +1606,6 @@ mod tests {
     use serde_json::json;
     use std::cell::RefCell;
     use std::time::Duration;
-    use tracing::info;
 
     fn make_test_app_set() -> Rc<Mutex<VecAppSet>> {
         Rc::new(Mutex::new(VecAppSet::new(vec![App::builder()

--- a/omaha-client/src/state_machine/builder.rs
+++ b/omaha-client/src/state_machine/builder.rs
@@ -293,7 +293,7 @@ where
                 app_set.load(&*storage),
                 update_check::Context::load(&*storage)
             );
-            tracing::info!("Omaha app set: {:?}", app_set.get_apps());
+            log::info!("Omaha app set: {:?}", app_set.get_apps());
             context
         };
 

--- a/omaha-client/src/state_machine/update_check.rs
+++ b/omaha-client/src/state_machine/update_check.rs
@@ -14,9 +14,9 @@ use crate::{
     storage::{Storage, StorageExt},
     time::PartialComplexTime,
 };
+use log::error;
 use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
-use tracing::error;
 
 // These are the keys used to persist data to storage.
 pub const CONSECUTIVE_FAILED_UPDATE_CHECKS: &str = "consecutive_failed_update_checks";

--- a/omaha-client/src/storage.rs
+++ b/omaha-client/src/storage.rs
@@ -10,8 +10,8 @@ use crate::time::system_time_conversion::{
     checked_system_time_to_micros_from_epoch, micros_from_epoch_to_system_time,
 };
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
+use log::error;
 use std::time::SystemTime;
-use tracing::error;
 
 mod memory;
 pub use memory::MemStorage;


### PR DESCRIPTION
* Complete the migration from tracing to log.
* Update dependencies.
* Bump release to 0.3.7 for both mock-omaha-server and omaha-client.