### PR TITLE
Update omaha-client to hyper 1.x

### DIFF
--- a/mock-omaha-server/Cargo.toml
+++ b/mock-omaha-server/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "mock-omaha-server"
-version = "0.3.8"
+version = "0.4.0"
 edition = "2024"
 description = "Mock implementation of the server end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -19,7 +19,7 @@ exclude = [".*"]
 
 [features]
 default = ["tokio"]
-tokio = ["dep:tokio", "hyper/tcp"]
+tokio = ["dep:tokio"]
 
 [dependencies]
 anyhow = "1.0"
@@ -27,9 +27,12 @@ argh = "0.1"
 derive_builder = "0.20"
 futures = "0.3"
 hex = "0.4"
-hyper = { version = "0.14.19", default-features = false, features = ["http1", "server", "stream"] }
+http = "1"
+http-body-util = "0.1"
+hyper = { version = "1", default-features = false, features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "server-auto"] }
 log = "0.4"
-omaha_client = { version = "0.3", path = "../omaha-client" }
+omaha_client = { version = "0.4", path = "../omaha-client" }
 p256 = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/mock-omaha-server/src/lib.rs
+++ b/mock-omaha-server/src/lib.rs
@@ -9,11 +9,9 @@
 use anyhow::Error;
 use derive_builder::Builder;
 use futures::prelude::*;
+use http::{Method, Request, Response, StatusCode, header};
 use hyper::body::Bytes;
-use hyper::server::Server;
-use hyper::server::accept::from_stream;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Method, Request, Response, StatusCode, header};
+use hyper::service::service_fn;
 use omaha_client::cup_ecdsa::PublicKeyId;
 use omaha_client::cup_ecdsa::test_support::{
     make_default_private_key_for_test, make_default_public_key_id_for_test,
@@ -22,7 +20,6 @@ use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::convert::Infallible;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 #[cfg(not(target_os = "fuchsia"))]
@@ -255,22 +252,35 @@ impl OmahaServer {
             )
         };
 
-        let make_svc = make_service_fn(move |_socket| {
+        let make_svc = service_fn(move |req| {
             let arc_server = Arc::clone(&arc_server);
-            async move {
-                Ok::<_, Infallible>(service_fn(move |req| {
-                    let arc_server = Arc::clone(&arc_server);
-                    async move { handle_request(req, &arc_server).await }
-                }))
+            async move { handle_request(req, &arc_server).await }
+        });
+
+        let server_task = fasync::Task::spawn(async move {
+            use hyper_util::server::conn::auto::Builder;
+            while let Some(conn) = connections.next().await {
+                let conn = match conn {
+                    Ok(c) => c,
+                    Err(e) => {
+                        log::error!("Error accepting connections: {}", e);
+                        continue;
+                    }
+                };
+
+                let make_svc = make_svc.clone();
+                fasync::Task::spawn(async move {
+                    if let Err(e) = Builder::new(fuchsia_hyper::Executor)
+                        .serve_connection(conn, make_svc)
+                        .await
+                    {
+                        log::error!("Error serving connection: {}", e);
+                    }
+                })
+                .detach();
             }
         });
 
-        let server = Server::builder(from_stream(connections))
-            .executor(fuchsia_hyper::Executor)
-            .serve(make_svc)
-            .unwrap_or_else(|e| panic!("error serving omaha server: {e}"));
-
-        let server_task = fasync::Task::spawn(server);
         Ok((format!("http://{addr}/"), Some(server_task)))
     }
 
@@ -287,14 +297,9 @@ impl OmahaServer {
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)
         };
 
-        let make_svc = make_service_fn(move |_socket| {
+        let make_svc = service_fn(move |req| {
             let arc_server = Arc::clone(&arc_server);
-            async {
-                Ok::<_, Infallible>(service_fn(move |req| {
-                    let arc_server = Arc::clone(&arc_server);
-                    async move { handle_request(req, &arc_server).await }
-                }))
-            }
+            async move { handle_request(req, &arc_server).await }
         });
 
         let listener = TcpListener::bind(&addr)
@@ -304,13 +309,27 @@ impl OmahaServer {
         let addr = listener.local_addr()?;
 
         let server = async move {
-            Server::builder(from_stream(
-                TcpListenerStream(listener).map_ok(ConnectionStream::Tcp),
-            ))
-            .executor(fuchsia_hyper::Executor)
-            .serve(make_svc)
-            .await
-            .unwrap_or_else(|e| panic!("error serving omaha server: {e}"));
+            use hyper_util::server::conn::auto::Builder;
+            let mut stream = TcpListenerStream(listener);
+            while let Some(conn) = stream.next().await {
+                let conn = match conn {
+                    Ok(c) => hyper_util::rt::TokioIo::new(c),
+                    Err(e) => {
+                        log::error!("Error accepting connections: {}", e);
+                        continue;
+                    }
+                };
+                let make_svc = make_svc.clone();
+                fasync::Task::spawn(async move {
+                    if let Err(e) = Builder::new(fuchsia_hyper::Executor)
+                        .serve_connection(conn, make_svc)
+                        .await
+                    {
+                        log::error!("Error serving connection: {}", e);
+                    }
+                })
+                .detach();
+            }
         };
 
         let server_task = fasync::Task::spawn(server);
@@ -330,14 +349,9 @@ impl OmahaServer {
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0)
         };
 
-        let make_svc = make_service_fn(move |_socket| {
+        let make_svc = service_fn(move |req| {
             let arc_server = Arc::clone(&arc_server);
-            async {
-                Ok::<_, Infallible>(service_fn(move |req| {
-                    let arc_server = Arc::clone(&arc_server);
-                    async move { handle_request(req, &arc_server).await }
-                }))
-            }
+            async move { handle_request(req, &arc_server).await }
         });
 
         let listener = TcpListener::bind(&addr)
@@ -347,10 +361,26 @@ impl OmahaServer {
         let addr = listener.local_addr()?;
 
         let server_task = tokio::spawn(async move {
-            let connections = TcpListenerStream(listener).map_ok(ConnectionStream::Tcp);
-            let _ = Server::builder(from_stream(connections))
-                .serve(make_svc)
-                .await;
+            use hyper_util::server::conn::auto::Builder;
+            let mut stream = TcpListenerStream(listener);
+            while let Some(conn) = stream.next().await {
+                let conn = match conn {
+                    Ok(c) => hyper_util::rt::TokioIo::new(c),
+                    Err(e) => {
+                        log::error!("Error accepting connections: {}", e);
+                        continue;
+                    }
+                };
+                let make_svc = make_svc.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = Builder::new(hyper_util::rt::TokioExecutor::new())
+                        .serve_connection(conn, make_svc)
+                        .await
+                    {
+                        log::error!("Error serving connection: {}", e);
+                    }
+                });
+            }
         });
         Ok((format!("http://{addr}/"), Some(server_task)))
     }
@@ -410,9 +440,9 @@ fn make_etag(
 }
 
 pub async fn handle_request(
-    req: Request<Body>,
+    req: Request<hyper::body::Incoming>,
     omaha_server: &Mutex<OmahaServer>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<http_body_util::Full<Bytes>>, Error> {
     log::debug!("{req:#?}");
     if req.uri().path() == "/set_responses_by_appid" {
         return handle_set_responses(req, omaha_server).await;
@@ -422,12 +452,13 @@ pub async fn handle_request(
 }
 
 pub async fn handle_set_responses(
-    req: Request<Body>,
+    req: Request<hyper::body::Incoming>,
     omaha_server: &Mutex<OmahaServer>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<http_body_util::Full<Bytes>>, Error> {
+    use http_body_util::BodyExt;
     assert_eq!(req.method(), Method::POST);
 
-    let req_body = hyper::body::to_bytes(req).await?;
+    let req_body = req.into_body().collect().await?.to_bytes();
     let req_json: HashMap<String, ResponseAndMetadata> =
         serde_json::from_slice(&req_body).expect("parse json");
     {
@@ -441,13 +472,14 @@ pub async fn handle_set_responses(
     let builder = Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_LENGTH, 0);
-    Ok(builder.body(Body::empty()).unwrap())
+    Ok(builder.body(http_body_util::Full::default()).unwrap())
 }
 
 pub async fn handle_omaha_request(
-    req: Request<Body>,
+    req: Request<hyper::body::Incoming>,
     omaha_server: &Mutex<OmahaServer>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<http_body_util::Full<Bytes>>, Error> {
+    use http_body_util::BodyExt;
     #[cfg(feature = "tokio")]
     let omaha_server = omaha_server.lock().await.clone();
     #[cfg(fasync)]
@@ -461,12 +493,12 @@ pub async fn handle_omaha_request(
         log::error!(
             "Received a request before |responses_by_appid| was set; returning an empty response with status 500."
         );
-        return Ok(builder.body(Body::empty()).unwrap());
+        return Ok(builder.body(http_body_util::Full::default()).unwrap());
     }
 
     let uri_string = req.uri().to_string();
 
-    let req_body = hyper::body::to_bytes(req).await?;
+    let req_body = req.into_body().collect().await?.to_bytes();
     let req_json: serde_json::Value = serde_json::from_slice(&req_body).expect("parse json");
 
     let request = req_json.get("request").unwrap();
@@ -688,7 +720,9 @@ pub async fn handle_omaha_request(
         builder = builder.header(header::ETAG, etag);
     }
 
-    Ok(builder.body(Body::from(response_data)).unwrap())
+    Ok(builder
+        .body(http_body_util::Full::new(Bytes::from(response_data)))
+        .unwrap())
 }
 
 #[cfg(test)]
@@ -697,9 +731,9 @@ mod tests {
     use anyhow::Context;
     #[cfg(fasync)]
     use fuchsia_async as fasync;
-    use hyper::Client;
+    use hyper_util::client::legacy::Client;
     #[cfg(feature = "tokio")]
-    use hyper::client::HttpConnector;
+    use hyper_util::client::legacy::connect::HttpConnector;
 
     #[cfg(fasync)]
     async fn new_http_client() -> Client<fuchsia_hyper::HyperConnector> {
@@ -707,8 +741,8 @@ mod tests {
     }
 
     #[cfg(feature = "tokio")]
-    async fn new_http_client() -> Client<HttpConnector> {
-        Client::new()
+    async fn new_http_client() -> Client<HttpConnector, http_body_util::Full<Bytes>> {
+        Client::builder(hyper_util::rt::TokioExecutor::new()).build_http()
     }
 
     #[cfg_attr(fasync, fasync::run_singlethreaded(test))]
@@ -748,15 +782,19 @@ mod tests {
             }
         });
         let request = Request::post(&server)
-            .body(Body::from(body.to_string()))
+            .body(http_body_util::Full::new(Bytes::from(body.to_string())))
             .unwrap();
 
         let response = client.request(request).await?;
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response)
+        use http_body_util::BodyExt;
+        let body = response
+            .into_body()
+            .collect()
             .await
-            .context("reading response body")?;
+            .context("reading response body")?
+            .to_bytes();
         let obj: serde_json::Value =
             serde_json::from_slice(&body).context("parsing response json")?;
 
@@ -819,15 +857,19 @@ mod tests {
                 }
             });
             let request = Request::post(&server_url)
-                .body(Body::from(body.to_string()))
+                .body(http_body_util::Full::new(Bytes::from(body.to_string())))
                 .unwrap();
 
             let response = client.request(request).await?;
 
             assert_eq!(response.status(), StatusCode::OK);
-            let body = hyper::body::to_bytes(response)
+            use http_body_util::BodyExt;
+            let body = response
+                .into_body()
+                .collect()
                 .await
-                .context("reading response body")?;
+                .context("reading response body")?
+                .to_bytes();
             let obj: serde_json::Value =
                 serde_json::from_slice(&body).context("parsing response json")?;
 
@@ -853,7 +895,7 @@ mod tests {
                 }
             });
             let request = Request::post(format!("{server_url}set_responses_by_appid"))
-                .body(Body::from(body.to_string()))
+                .body(http_body_util::Full::new(Bytes::from(body.to_string())))
                 .unwrap();
             let client = new_http_client().await;
             let response = client.request(request).await?;
@@ -873,16 +915,20 @@ mod tests {
                 }
             });
             let request = Request::post(&server_url)
-                .body(Body::from(body.to_string()))
+                .body(http_body_util::Full::new(Bytes::from(body.to_string())))
                 .unwrap();
 
             let client = new_http_client().await;
             let response = client.request(request).await?;
 
             assert_eq!(response.status(), StatusCode::OK);
-            let body = hyper::body::to_bytes(response)
+            use http_body_util::BodyExt;
+            let body = response
+                .into_body()
+                .collect()
                 .await
-                .context("reading response body")?;
+                .context("reading response body")?
+                .to_bytes();
             let obj: serde_json::Value =
                 serde_json::from_slice(&body).context("parsing response json")?;
 
@@ -927,7 +973,7 @@ mod tests {
             }
         });
         let request = Request::post(&server)
-            .body(Body::from(body.to_string()))
+            .body(http_body_util::Full::new(Bytes::from(body.to_string())))
             .unwrap();
         let response = client.request(request).await?;
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
@@ -975,7 +1021,7 @@ mod tests {
             &server_url,
             make_default_public_key_id_for_test()
         ))
-        .body(Body::from(body.to_string()))
+        .body(http_body_util::Full::new(Bytes::from(body.to_string())))
         .unwrap();
 
         let response = client.request(request).await?;
@@ -993,7 +1039,7 @@ mod tests {
         feature = "tokio",
         tokio::test,
         should_panic(
-            expected = "called `Result::unwrap()` on an `Err` value: hyper::Error(IncompleteMessage)"
+            expected = "called `Result::unwrap()` on an `Err` value: hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage))"
         )
     )]
     async fn test_server_expect_cup_panic() {
@@ -1033,7 +1079,7 @@ mod tests {
         // no CUP, but we set .require_cup(true) above, so mock-omaha-server will
         // panic. (See should_panic above.)
         let request = Request::post(&server_url)
-            .body(Body::from(body.to_string()))
+            .body(http_body_util::Full::new(Bytes::from(body.to_string())))
             .unwrap();
         let _response = client.request(request).await.unwrap();
     }

--- a/omaha-client/Cargo.toml
+++ b/omaha-client/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "omaha_client"
-version = "0.3.8"
+version = "0.4.0"
 edition = "2024"
 description = "Platform- and product-agnostic implementation of the client end of the Omaha Protocol"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -24,8 +24,10 @@ ecdsa =  { version = "0.14.8", features = ["pem"] }
 elliptic-curve = "0.12.3"
 futures = "0.3"
 hex = "0.4"
-http = "0.2.4"
-hyper = "0.14.19"
+http = "1.0"
+http-body-util = "0.1.1"
+hyper = "1.8.1"
+hyper-util = "0.1.3"
 itertools = "0.14"
 log = "0.4"
 p256 = "0.11"
@@ -41,11 +43,12 @@ thiserror = "2.0"
 typed-builder = "0.23"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 pin-project = "1.1"
+bytes = "1.11.1"
 
 [dev-dependencies]
 argh = "0.1"
 assert_matches = "1.5.0"
 futures-timer = "0.3"
-hyper-rustls = { version = "0.25", features = ["http2"] }
+hyper-rustls = { version = "0.27", features = ["http2"] }
 tokio = { version = "1", features = ["full"] }
 url = "2"

--- a/omaha-client/examples/hello-world/http_request.rs
+++ b/omaha-client/examples/hello-world/http_request.rs
@@ -7,12 +7,10 @@
 // those terms.
 use {
     futures::{FutureExt as _, future::BoxFuture},
-    hyper::{
-        Client, Request, Response,
-        body::Body,
-        client::{HttpConnector, ResponseFuture},
-    },
-    omaha_client::http_request::{Error, HttpRequest},
+    http::{Request, Response},
+    http_body_util::BodyExt as _,
+    hyper_util::client::legacy::{Client, ResponseFuture, connect::HttpConnector},
+    omaha_client::http_request::{Body, Error, HttpRequest},
     std::time::Duration,
 };
 
@@ -47,7 +45,11 @@ async fn collect_from_future_on_timeout(
 async fn collect_from_future(response_future: ResponseFuture) -> Result<Response<Vec<u8>>, Error> {
     let response = response_future.await.map_err(Error::from)?;
     let (parts, body) = response.into_parts();
-    let bytes = hyper::body::to_bytes(body).await?;
+    let bytes = body
+        .collect()
+        .await
+        .map_err(|_| Error::new_timeout())?
+        .to_bytes();
     Ok(Response::from_parts(parts, bytes.to_vec()))
 }
 
@@ -65,7 +67,7 @@ impl MinimalHttpRequest {
             .https_or_http()
             .enable_all_versions()
             .build();
-        let client = Client::builder().build(https);
+        let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
         MinimalHttpRequest { timeout, client }
     }
 }

--- a/omaha-client/src/cup_ecdsa.rs
+++ b/omaha-client/src/cup_ecdsa.rs
@@ -7,8 +7,8 @@
 // those terms.
 
 use crate::http_uri_ext::HttpUriExt as _;
+use http::header::ToStrError;
 use http::{Response, Uri};
-use hyper::header::ETAG;
 use p256::ecdsa::{DerSignature, signature::Verifier as _};
 use rand::{Rng, thread_rng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -33,7 +33,7 @@ pub enum CupVerificationError {
     #[error("etag header missing.")]
     EtagHeaderMissing,
     #[error("etag header is not a string.")]
-    EtagNotString(hyper::header::ToStrError),
+    EtagNotString(ToStrError),
     #[error("etag header is malformed.")]
     EtagMalformed,
     #[error("etag header's request hash is malformed.")]
@@ -264,7 +264,7 @@ impl Cupv2RequestHandler for StandardCupv2Handler {
 
         let etag_header = resp
             .headers()
-            .get(ETAG)
+            .get(http::header::ETAG)
             .ok_or(CupVerificationError::EtagHeaderMissing)?
             .to_str()
             .map_err(CupVerificationError::EtagNotString)
@@ -631,8 +631,8 @@ mod tests {
             test_support::make_standard_intermediate_for_test(Request::default());
         let request_metadata = cup_handler.decorate_request(&mut intermediate)?;
 
-        // No .header(ETAG, <val>), which is a problem.
-        let response: Response<Vec<u8>> = hyper::Response::builder()
+        // No .header(http::header::ETAG, <val>), which is a problem.
+        let response: Response<Vec<u8>> = http::Response::builder()
             .status(200)
             .body("foo".as_bytes().to_vec())?;
 
@@ -654,9 +654,9 @@ mod tests {
             test_support::make_standard_intermediate_for_test(Request::default());
         let request_metadata = cup_handler.decorate_request(&mut intermediate)?;
 
-        let response: Response<Vec<u8>> = hyper::Response::builder()
+        let response: Response<Vec<u8>> = http::Response::builder()
             .status(200)
-            .header(ETAG, "\u{FEFF}")
+            .header(http::header::ETAG, "\u{FEFF}")
             .body("foo".as_bytes().to_vec())?;
 
         assert_matches!(
@@ -740,9 +740,9 @@ mod tests {
                 None,
             ),
         ] {
-            let response: Response<Vec<u8>> = hyper::Response::builder()
+            let response: Response<Vec<u8>> = http::Response::builder()
                 .status(200)
-                .header(ETAG, etag)
+                .header(http::header::ETAG, etag)
                 .body(response_body.as_bytes().to_vec())?;
             let actual_err = cup_handler
                 .verify_response(&request_metadata, &response, public_key_id)
@@ -780,9 +780,9 @@ mod tests {
             hex::encode(Sha256::digest(&request_metadata.request_body))
         );
 
-        let response: Response<Vec<u8>> = hyper::Response::builder()
+        let response: Response<Vec<u8>> = http::Response::builder()
             .status(200)
-            .header(ETAG, etag)
+            .header(http::header::ETAG, etag)
             .body(response_body.as_bytes().to_vec())?;
         Ok((request_metadata, response))
     }

--- a/omaha-client/src/http_request.rs
+++ b/omaha-client/src/http_request.rs
@@ -7,12 +7,18 @@
 // those terms.
 
 use {
+    bytes::Bytes,
     futures::future::BoxFuture,
     futures::prelude::*,
-    hyper::{Body, Request, Response},
+    http::{Request, Response},
+    http_body_util::Full,
 };
 
 pub mod mock;
+
+/// A wrapper around Hyper's Body type, to provide a simple request->response style of API for
+/// the state machine to use.
+pub type Body = Full<Bytes>;
 
 /// A trait for providing HTTP capabilities to the StateMachine.
 ///
@@ -35,7 +41,7 @@ pub trait HttpRequest {
 pub struct Error {
     kind: ErrorKind,
     #[source]
-    source: Option<hyper::Error>,
+    source: Option<hyper_util::client::legacy::Error>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -72,16 +78,13 @@ impl Error {
     }
 }
 
-impl From<hyper::Error> for Error {
-    fn from(error: hyper::Error) -> Self {
-        let kind = if error.is_user() {
-            ErrorKind::User
-        } else {
-            ErrorKind::Transport
-        };
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(error: hyper_util::client::legacy::Error) -> Self {
+        // hyper_util::client::legacy::Error doesn't implement is_user() or is_timeout()
+        let kind = ErrorKind::Transport;
         Error {
             kind,
-            source: error.into(),
+            source: Some(error),
         }
     }
 }
@@ -109,6 +112,6 @@ pub struct StubHttpRequest;
 
 impl HttpRequest for StubHttpRequest {
     fn request(&mut self, _req: Request<Body>) -> BoxFuture<'_, Result<Response<Vec<u8>>, Error>> {
-        future::ok(Response::default()).boxed()
+        future::ok(Response::builder().body(vec![]).unwrap()).boxed()
     }
 }

--- a/omaha-client/src/http_request/mock.rs
+++ b/omaha-client/src/http_request/mock.rs
@@ -7,10 +7,11 @@
 // those terms.
 
 use crate::http_request::{Error, HttpRequest};
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::prelude::*;
-use http::StatusCode;
-use hyper::{Body, Request, Response};
+use http::{Request, Response, StatusCode};
+use http_body_util::{BodyExt, Full};
 use pretty_assertions::assert_eq;
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
@@ -20,13 +21,16 @@ use futures::executor::block_on;
 #[derive(Debug, Default)]
 pub struct MockHttpRequest {
     // The requests made using this mock.
-    requests: Rc<RefCell<Vec<Request<Body>>>>,
+    requests: Rc<RefCell<Vec<Request<Full<Bytes>>>>>,
     // The queue of fake responses for the upcoming requests.
     responses: VecDeque<Result<Response<Vec<u8>>, Error>>,
 }
 
 impl HttpRequest for MockHttpRequest {
-    fn request(&mut self, req: Request<Body>) -> BoxFuture<'_, Result<Response<Vec<u8>>, Error>> {
+    fn request(
+        &mut self,
+        req: Request<Full<Bytes>>,
+    ) -> BoxFuture<'_, Result<Response<Vec<u8>>, Error>> {
         self.requests.borrow_mut().push(req);
 
         future::ready(if let Some(resp) = self.responses.pop_front() {
@@ -54,14 +58,14 @@ impl MockHttpRequest {
         Default::default()
     }
 
-    pub fn from_request_cell(request: Rc<RefCell<Vec<Request<Body>>>>) -> Self {
+    pub fn from_request_cell(request: Rc<RefCell<Vec<Request<Full<Bytes>>>>>) -> Self {
         Self {
             requests: request,
             ..Default::default()
         }
     }
 
-    pub fn get_request_cell(&self) -> Rc<RefCell<Vec<Request<Body>>>> {
+    pub fn get_request_cell(&self) -> Rc<RefCell<Vec<Request<Full<Bytes>>>>> {
         Rc::clone(&self.requests)
     }
 
@@ -73,13 +77,13 @@ impl MockHttpRequest {
         self.responses.push_back(Err(error));
     }
 
-    pub fn assert_method(&self, method: &hyper::Method) {
+    pub fn assert_method(&self, method: &http::Method) {
         assert_eq!(method, self.requests.borrow().last().unwrap().method());
     }
 
     pub fn assert_uri(&self, uri: &str) {
         assert_eq!(
-            &uri.parse::<hyper::Uri>().unwrap(),
+            &uri.parse::<http::Uri>().unwrap(),
             self.requests.borrow().last().unwrap().uri()
         );
     }
@@ -92,17 +96,29 @@ impl MockHttpRequest {
         assert_eq!(headers[key], value);
     }
 
-    fn take_request(&self) -> Request<Body> {
+    fn take_request(&self) -> Request<Full<Bytes>> {
         self.requests.borrow_mut().pop().unwrap()
     }
 
     pub async fn assert_body(&self, body: &[u8]) {
-        let bytes = hyper::body::to_bytes(self.take_request()).await.unwrap();
+        let bytes = self
+            .take_request()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
         assert_eq!(body, &bytes);
     }
 
     pub async fn assert_body_str(&self, body: &str) {
-        let bytes = hyper::body::to_bytes(self.take_request()).await.unwrap();
+        let bytes = self
+            .take_request()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
         assert_eq!(body, String::from_utf8_lossy(&bytes));
     }
 }
@@ -122,7 +138,7 @@ fn test_mock() {
         let response = mock.request(req).await.unwrap();
         assert_eq!(res_body, response.into_body());
 
-        mock.assert_method(&hyper::Method::GET);
+        mock.assert_method(&http::Method::GET);
         mock.assert_uri(uri);
         mock.assert_header("X-Custom-Foo", "Bar");
         mock.assert_body(req_body.as_slice()).await;
@@ -138,7 +154,7 @@ fn test_missing_response() {
         assert_eq!(res_body, response.into_body());
 
         let response2 = mock.request(Request::default()).await.unwrap();
-        assert_eq!(response2.status(), hyper::StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(response2.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
     });
 }
 

--- a/omaha-client/src/request_builder.rs
+++ b/omaha-client/src/request_builder.rs
@@ -13,6 +13,7 @@ use crate::{
     common::{App, UserCounting},
     configuration::Config,
     cup_ecdsa::{CupDecorationError, CupRequest, Cupv2RequestHandler, RequestMetadata},
+    http_request::Body,
     protocol::{
         PROTOCOL_V3,
         request::{
@@ -253,7 +254,7 @@ impl<'a> RequestBuilder<'a> {
     pub fn build(
         &self,
         cup_handler: Option<&impl Cupv2RequestHandler>,
-    ) -> Result<(http::Request<hyper::Body>, Option<RequestMetadata>)> {
+    ) -> Result<(http::Request<Body>, Option<RequestMetadata>)> {
         let (intermediate, request_metadata) = self.build_intermediate(cup_handler)?;
         if self
             .app_entries
@@ -263,7 +264,7 @@ impl<'a> RequestBuilder<'a> {
             info!("Building Request: {}", intermediate);
         }
         Ok((
-            Into::<Result<http::Request<hyper::Body>>>::into(intermediate)?,
+            Into::<Result<http::Request<Body>>>::into(intermediate)?,
             request_metadata,
         ))
     }
@@ -370,9 +371,9 @@ impl Display for Intermediate {
     }
 }
 
-impl From<Intermediate> for Result<http::Request<hyper::Body>> {
+impl From<Intermediate> for Result<http::Request<Body>> {
     fn from(intermediate: Intermediate) -> Self {
-        let mut builder = hyper::Request::post(&intermediate.uri);
+        let mut builder = http::Request::post(&intermediate.uri);
         for (key, value) in &intermediate.headers {
             builder = builder.header(*key, value);
         }

--- a/omaha-client/src/request_builder/tests.rs
+++ b/omaha-client/src/request_builder/tests.rs
@@ -20,6 +20,8 @@ use pretty_assertions::assert_eq;
 use serde_json::json;
 use url::Url;
 
+use http_body_util::BodyExt;
+
 /// Test that a simple request's fields are all correct:
 ///
 /// - All request fields are set properly from the Config
@@ -304,7 +306,7 @@ fn test_single_request() {
     // Extract the request body out into a concatenated stream of Chunks, into a slice, so
     // that serde can be used to parse the body into a JSON Value object that can be compared
     // with the expected json constructed above.
-    let body = block_on(hyper::body::to_bytes(body)).unwrap();
+    let body = block_on(body.collect()).unwrap().to_bytes();
     let actual: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(expected, actual);

--- a/omaha-client/src/state_machine.rs
+++ b/omaha-client/src/state_machine.rs
@@ -40,7 +40,6 @@ use p256::ecdsa::DerSignature;
 use std::{
     cmp::min,
     collections::HashMap,
-    convert::TryInto,
     rc::Rc,
     str::Utf8Error,
     time::{Duration, Instant, SystemTime},
@@ -1414,7 +1413,7 @@ where
     /// handle them as part of parsing the response body.
     async fn make_request(
         http_client: &mut HR,
-        request: http::Request<hyper::Body>,
+        request: http::Request<crate::http_request::Body>,
     ) -> Result<HttpResponse<Vec<u8>>, http_request::Error> {
         info!("Making http request to: {}", request.uri());
         http_client.request(request).await.map_err(|err| {
@@ -1601,6 +1600,7 @@ mod tests {
     use futures::executor::{LocalPool, block_on};
     use futures::future::LocalBoxFuture;
     use futures::task::LocalSpawnExt;
+    use http_body_util::BodyExt as _;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::cell::RefCell;
@@ -1653,7 +1653,7 @@ mod tests {
     async fn assert_request<'a>(http: &MockHttpRequest, request_builder: RequestBuilder<'a>) {
         let cup_handler = make_cup_handler_for_test();
         let (request, _request_metadata) = request_builder.build(Some(&cup_handler)).unwrap();
-        let body = hyper::body::to_bytes(request).await.unwrap();
+        let body = request.into_body().collect().await.unwrap().to_bytes();
         // Compare string instead of Vec<u8> for easier debugging.
         let body_str = String::from_utf8_lossy(&body);
         http.assert_body_str(&body_str).await;


### PR DESCRIPTION
This updates omaha-client to hyper 1.x. Since this is a breaking change, it also bumps the major version number.